### PR TITLE
Feature/add users to lists

### DIFF
--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -1,9 +1,10 @@
 class ListsController < ApplicationController
+  before_action :authenticate_user
   before_action :set_list, only: [:show, :update, :destroy]
 
   # GET /lists
-  def index
-    @lists = List.all
+  def index    
+    @lists = current_user.lists.all
 
     render json: @lists
   end
@@ -15,7 +16,7 @@ class ListsController < ApplicationController
 
   # POST /lists
   def create
-    @list = List.new(list_params)
+    @list = current_user.lists.new(list_params)
 
     if @list.save
       render json: @list, status: :created, location: @list
@@ -41,7 +42,8 @@ class ListsController < ApplicationController
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_list
-      @list = List.find(params[:id])
+      # @list = List.find(params[:id])
+      @list = current_user.lists.find(params[:id])
     end
 
     # Only allow a list of trusted parameters through.

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,7 +3,6 @@ class UsersController < ApplicationController
         @user = User.create(user_params)
         if @user.save
             auth_token = Knock::AuthToken.new payload: {sub: @user.id}
-            # render json: @user, status: :created
             render json: {username: @user.username, jwt: auth_token.token}, status: :created
         else
             render json: @user.errors, status: :unprocessable_entity

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -27,8 +27,7 @@ class List < ApplicationRecord
     end
     
     # relationships
-    # comment out belong_to until Auth completed
-    # belongs_to :user
+    belongs_to :user
     has_many :movie_lists
     # issues with dependant: :destroy to address later
     # , dependant: :destroy

--- a/spec/models/list_spec.rb
+++ b/spec/models/list_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe List, type: :model do
     )
   }
 
-  pending "user_id" do
+  describe "user_id" do
     
     it "is required" do
       subject.user_id = nil


### PR DESCRIPTION
lists now belong to users and cannot be created without an a user id associated. Users can only view and delete lists they created.